### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: ['main']
 
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 


### PR DESCRIPTION
Potential fix for [https://github.com/KnowOneActual/BB_Website/security/code-scanning/16](https://github.com/KnowOneActual/BB_Website/security/code-scanning/16)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is restricted to the minimum required scope.

Best single fix without changing functionality: in `.github/workflows/snyk.yml`, add a root-level `permissions:` section after the trigger (`on:` block) and before `env:`:

- `contents: read`

This is sufficient for `actions/checkout` and typical read-only workflow operations here. It preserves behavior while preventing unintended inherited write privileges.

No imports, methods, or dependencies are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
